### PR TITLE
Fix DoubleRenderError

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,17 +4,17 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   def ensure_user
-    unless current_user.present?
-      session[:sandr] ||= request.url unless controller_name.match('session')
-      redirect_to user_bike_index_omniauth_authorize_path and return
-    end
+    return true if current_user.present?
+
+    session[:sandr] ||= request.url unless controller_name.match('session')
+    redirect_to user_bike_index_omniauth_authorize_path and return
   end
 
   def ensure_superuser
-    ensure_user
-    unless current_user && current_user.superuser?
-      redirect_to root_url and return
-    end
+    return unless ensure_user
+    return true if current_user.superuser?
+
+    redirect_to root_url and return
   end
 
   def ssl_configured?

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe AccountsController, type: :controller do
+  describe 'ensure_superuser' do
+    context 'with no cookies' do
+      it 'redirects the request' do
+        get :index
+
+        expect(response.status).to eq(302)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The double render error in #39 was being caused between `ensure_user` and `ensure_superuser` when there were no cookies set. New auth logic fixes this issue.