### PR TITLE
Improve Serial Searching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'devise'
 gem 'omniauth-oauth2', '~> 1.3.1'
 gem 'omniauth-bike-index'
 gem 'rack-cors', :require => 'rack/cors'
+gem 'pg_search'
 
 gem 'bundler', '>= 1.8.4' # required for rails-assets.org - JS and CSS assets
 source 'https://rails-assets.org' do # JS land is crazy, so lock everything

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,10 @@ GEM
     parser (2.3.1.2)
       ast (~> 2.2)
     pg (0.18.4)
+    pg_search (2.0.1)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      arel (>= 6)
     pkg-config (1.1.7)
     powerpack (0.1.1)
     pry (0.10.4)
@@ -371,6 +375,7 @@ DEPENDENCIES
   omniauth-bike-index
   omniauth-oauth2 (~> 1.3.1)
   pg (~> 0.18)
+  pg_search
   puma (~> 3.0)
   rack-cors
   rails (~> 5.0.0, >= 5.0.0.1)
@@ -398,4 +403,4 @@ RUBY VERSION
    ruby 2.2.5p319
 
 BUNDLED WITH
-   1.13.3
+   1.14.6

--- a/app/models/serial_search.rb
+++ b/app/models/serial_search.rb
@@ -2,11 +2,6 @@ class SerialSearch < ApplicationRecord
   validates_presence_of :serial
   validates_uniqueness_of :serial
 
-  include PgSearch
-  pg_search_scope :search_by_serial_number,
-                  against: :serial,
-                  using: :trigram
-
   has_many :log_lines
   has_many :ip_addresses, through: :log_lines
   has_many :bike_serial_searches
@@ -32,7 +27,7 @@ class SerialSearch < ApplicationRecord
 
   def self.text_search(query)
     if query.present?
-      search_by_serial_number(query)
+      where('serial % ?', query)
     else
       all
     end

--- a/app/models/serial_search.rb
+++ b/app/models/serial_search.rb
@@ -3,7 +3,9 @@ class SerialSearch < ApplicationRecord
   validates_uniqueness_of :serial
 
   include PgSearch
-  pg_search_scope :search_by_serial_number, against: :serial
+  pg_search_scope :search_by_serial_number,
+                  against: :serial,
+                  using: :trigram
 
   has_many :log_lines
   has_many :ip_addresses, through: :log_lines

--- a/app/models/serial_search.rb
+++ b/app/models/serial_search.rb
@@ -2,6 +2,9 @@ class SerialSearch < ApplicationRecord
   validates_presence_of :serial
   validates_uniqueness_of :serial
 
+  include PgSearch
+  pg_search_scope :search_by_serial_number, against: :serial
+
   has_many :log_lines
   has_many :ip_addresses, through: :log_lines
   has_many :bike_serial_searches
@@ -27,7 +30,7 @@ class SerialSearch < ApplicationRecord
 
   def self.text_search(query)
     if query.present?
-      where('serial @@ ?', query)
+      search_by_serial_number(query)
     else
       all
     end

--- a/db/migrate/20170613003053_add_pg_trgm_extension_to_db.rb
+++ b/db/migrate/20170613003053_add_pg_trgm_extension_to_db.rb
@@ -1,0 +1,9 @@
+class AddPgTrgmExtensionToDb < ActiveRecord::Migration[5.0]
+  def up
+    execute 'CREATE EXTENSION pg_trgm;'
+  end
+
+  def down
+    execute 'DROP EXTENSION pg_trgm'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170224203049) do
+ActiveRecord::Schema.define(version: 20170613003053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_trgm"
 
   create_table "bike_serial_searches", force: :cascade do |t|
     t.integer  "bike_id"

--- a/spec/controllers/serial_searches_controller_spec.rb
+++ b/spec/controllers/serial_searches_controller_spec.rb
@@ -48,7 +48,22 @@ RSpec.describe SerialSearchesController, type: :controller do
       it 'sorts by times_searched' do
         get :index, params: { sort: 'log_lines_count', direction: 'desc', per_page: '1' }
         expect(response.status).to eq 200
-        expect(assigns(:serial_searches)). to eq([serial_search_3])
+        expect(assigns(:serial_searches)).to eq([serial_search_3])
+      end
+    end
+
+    context 'sort by last request at' do
+      let!(:serial_search_1) { FactoryGirl.create(:serial_search, serial: 'WTU 326', log_lines_count: '2') }
+      let!(:serial_search_2) { FactoryGirl.create(:serial_search, serial: 'WTU 316', log_lines_count: '3') }
+
+      it 'sorts correctly when switching direction' do
+        get :index, params: { sort: 'log_lines_count', direction: 'asc', query: 'WTU' }
+
+        expect(response.status).to eq 200
+        expect(assigns(:serial_searches)).to eq([ serial_search_1, serial_search_2])
+
+        get :index, params: { sort: 'log_lines_count', direction: 'desc', query: 'WTU' }
+        expect(assigns(:serial_searches)).to eq([serial_search_2, serial_search_1])
       end
     end
 

--- a/spec/models/serial_search_spec.rb
+++ b/spec/models/serial_search_spec.rb
@@ -67,4 +67,20 @@ RSpec.describe SerialSearch, type: :model do
       end
     end
   end
+
+  describe '.text_search' do
+    let(:serial_search) { FactoryGirl.create(:serial_search, serial: 'Y524347') }
+
+    context 'with a complete matched serial' do
+      it 'returns the valid serial_search record' do
+        expect(SerialSearch.text_search('Y524347')).to include(serial_search)
+      end
+    end
+
+    context 'with a partial matched serial' do
+      it 'returns the valid serial_search record' do
+        expect(SerialSearch.text_search('Y524')).to include(serial_search)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Use pg_search and trigram to improve searching abilities for serial numbers. This works with sorting columns as well. Address #26.